### PR TITLE
Added a set of testable helper functions

### DIFF
--- a/src/components/keyboard/keyboard.js
+++ b/src/components/keyboard/keyboard.js
@@ -3,88 +3,90 @@ import { useEffect } from 'react';
 import keys from "../../sounds/keys.mp3";
 import './keyboard.css';
 
+// Import helper functions:
+
+import { isKeyBlack } from '../../helpers';
+import { createSprite } from '../../helpers';
+
 const useKeyboardBindings = (play, setKey, splash, keys) => {
-    useEffect(() => {
-      if(!splash) {
-        const keyHandler = e => {
-          if(document.activeElement.id !== 'bpmInput' && keys.includes(e.key)) {
-            play({ id: e.key });
-            setKey(e.key);
+  useEffect(() => {
+    if (!splash) {
+      const keyHandler = e => {
+        if (document.activeElement.id !== 'bpmInput' && keys.includes(e.key)) {
+          play({ id: e.key });
+          setKey(e.key);
 
-            let element;
+          let element;
 
-            document.getElementById('key-' + e.key) ?
-                element = [document.getElementById('key-' + e.key), 0]
-                : element = [document.getElementById('black-' + e.key), 1];
-    
-            if(element[0].classList.contains('keyPressed') 
-                || element[0].classList.contains('blackPressed')) {
+          document.getElementById('key-' + e.key) ?
+            element = [document.getElementById('key-' + e.key), 0]
+            : element = [document.getElementById('black-' + e.key), 1];
 
-                element[0].style.animation = 'none';
-                setTimeout(function(){ 
-                    element[0].style.animation = '';
-                }, 1); 
-            } else {
-                element[1] ? element[0].classList.add('blackPressed')
-                : element[0].classList.add('keyPressed');
-            }
+          if (element[0].classList.contains('keyPressed')
+            || element[0].classList.contains('blackPressed')) {
+
+            element[0].style.animation = 'none';
+            setTimeout(function () {
+              element[0].style.animation = '';
+            }, 1);
+          } else {
+            element[1] ? element[0].classList.add('blackPressed')
+              : element[0].classList.add('keyPressed');
           }
         }
-  
-        window.addEventListener('keydown', keyHandler);
-    
-        return () => {
-          window.removeEventListener('keydown', keyHandler);
-        };
       }
-    }, [play, setKey, splash, keys]);
-  };
+
+      window.addEventListener('keydown', keyHandler);
+
+      return () => {
+        window.removeEventListener('keydown', keyHandler);
+      };
+    }
+  }, [play, setKey, splash, keys]);
+};
 
 function Keyboard(props) {
-    const ordered = ['$', 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 'a', 'b', 'B', 'c', 'C', 'd', 'D', 'e', 'E',
-                     'f', 'g', 'G', 'h', 'H', 'i', 'I', 'j', 'J', 'k', 'l', 'L', 'm', '!', '%', '(',
-                     '*', '@', '^', 'n', 'o', 'O', 'p', 'P', 'q', 'Q', 'r', 's', 'S', 't', 'T', 'u',
-                     'v', 'V', 'w', 'W', 'x', 'y', 'Y', 'z', 'Z'];
+  const ordered = ['$', 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 'a', 'b', 'B', 'c', 'C', 'd', 'D', 'e', 'E',
+    'f', 'g', 'G', 'h', 'H', 'i', 'I', 'j', 'J', 'k', 'l', 'L', 'm', '!', '%', '(',
+    '*', '@', '^', 'n', 'o', 'O', 'p', 'P', 'q', 'Q', 'r', 's', 'S', 't', 'T', 'u',
+    'v', 'V', 'w', 'W', 'x', 'y', 'Y', 'z', 'Z'];
 
-    const keyboard = ['1', '!', '2', '@', '3', '4', '$', '5', '%', '6', '^', '7', '8', 
-                      '*', '9', '(', '0', 'q', 'Q', 'w', 'W', 'e', 'E', 'r', 't', 'T', 'y', 'Y', 'u',
-                      'i', 'I', 'o', 'O', 'p', 'P', 'a', 's', 'S', 'd', 'D', 'f', 'g', 'G', 'h', 'H',
-                      'j', 'J', 'k', 'l', 'L', 'z', 'Z', 'x', 'c', 'C', 'v', 'V', 'b', 'B', 'n', 'm'];
+  const keyboard = ['1', '!', '2', '@', '3', '4', '$', '5', '%', '6', '^', '7', '8',
+    '*', '9', '(', '0', 'q', 'Q', 'w', 'W', 'e', 'E', 'r', 't', 'T', 'y', 'Y', 'u',
+    'i', 'I', 'o', 'O', 'p', 'P', 'a', 's', 'S', 'd', 'D', 'f', 'g', 'G', 'h', 'H',
+    'j', 'J', 'k', 'l', 'L', 'z', 'Z', 'x', 'c', 'C', 'v', 'V', 'b', 'B', 'n', 'm'];
 
-    const map = { sprite: {}, volume: props.volume / 100 };
+  const map = createSprite(ordered, props.volume);
 
-    const [play] = useSound(keys, map);
-    useKeyboardBindings(play, props.setKey, props.splash, keyboard);
+  const [play] = useSound(keys, map);
+  useKeyboardBindings(play, props.setKey, props.splash, keyboard);
 
-    ordered.forEach((item, index) => {
-      map.sprite[item] = [(index * 7652), 7648];
-    });
-  
-    const clickPlay = (key) => {
-        play({ id: key });
-        props.setKey(key);
-    };
+  const clickPlay = (key) => {
+    play({ id: key });
+    props.setKey(key);
+  };
 
-    return (
-        <div id='keyboard'>
-          {keyboard.map((d, i) =>
-            !isNaN(d) || d !== d.toUpperCase() ?
-              <div id={'section-' + d.toString()} key={'list-' + d.toString()} className='section'>
-                <div onMouseDown={() => clickPlay(d.toString())} id={'key-' + d.toString()} className='key'>
-                  <span data-testid={'white-' + d} className='noselect'>{d}</span>
+  return (
+    <div id='keyboard'>
+      {keyboard.map((d, i) =>
+        !isKeyBlack(keyboard, i) ?
+          <div id={'section-' + d.toString()} key={'list-' + d.toString()} className='section'>
+            <div onMouseDown={() => clickPlay(d.toString())} id={'key-' + d.toString()} className='key'>
+              <span data-testid={'white-' + d} className='noselect'>{d}</span>
+            </div>
+
+            {(() => {
+              if (isKeyBlack(keyboard, i + 1)) {
+                return <div onMouseDown={() => clickPlay(keyboard[i + 1].toString())} id={'black-' + keyboard[i + 1].toString()} className='black_key'>
+                  <span data-testid={'black-' + keyboard[i + 1]} className='noselect'>{keyboard[i + 1]}</span>
                 </div>
-                {(() => {
-                  if (i + 1 < keyboard.length && keyboard[i + 1] === keyboard[i + 1].toString().toUpperCase()) {
-                    return <div onMouseDown={() => clickPlay(keyboard[i + 1].toString())} id={'black-' + keyboard[i+1].toString()} className='black_key'>
-                      <span data-testid={'black-' + keyboard[i + 1]} className='noselect'>{keyboard[i + 1]}</span>
-                    </div>
-                  }
-                })()}
-              </div>
-              : null
-          )}
-        </div>
-    );
+              }
+            })()}
+          </div>
+          : null
+      )}
+    </div>
+  );
 };
 
 export default Keyboard;

--- a/src/components/metronome/metronome.js
+++ b/src/components/metronome/metronome.js
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import useSound from 'use-sound';
 import './metronome.css';
+import { sanitiseBeat } from '../../helpers';
 
 import metronome from "../../sounds/metronome.mp3";
 
@@ -21,8 +22,8 @@ function Metronome(props) {
   return (
     <div id='metronome'>
       <img id='metroIcon' className='noselect' src='/svg/metronome.svg' alt='Metronome Icon' />
-      <input type="text" id='bpmInput' data-testid="bpmText" onChange={
-        (e) => e.target.value < 1000 ? setBpm(e.target.value) : {}}
+      <input type="text" id='bpmInput' data-testid="bpmText" onBlur={() => { if(bpm === '') setBpm('1') }} 
+        onChange={(e) => setBpm(sanitiseBeat(bpm, e.target.value))}
         style={{ width: ((bpm.length) * 13.5).toString() + 'px' }}
         value={bpm}></input>
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,70 @@
+const convertToNote = (key) => {
+    const midi = {
+        1: 'C2', '!': 'C#2', 2: 'D2', '@': 'D#2',
+        3: 'E2', 4: 'F2', '$': 'F#2', '5': 'G2', '%': 'G#2',
+        6: 'A2', '^': 'A#2', 7: 'B2', 8: 'C3', '*': 'C#3',
+        9: 'D3', '(': 'D#3', '0': 'E3', 'q': 'F3', 'Q': 'F#3',
+        'w': 'G3', 'W': 'G#3', 'e': 'A3', 'E': 'A#3', 'r': 'B3',
+        't': 'C4', 'T': 'C#4', 'y': 'D4', 'Y': 'D#4', 'u': 'E4',
+        'i': 'F4', 'I': 'F#4', 'o': 'G4', 'O': 'G#4', 'p': 'A4',
+        'P': 'A#4', 'a': 'B4', 's': 'C5', 'S': 'C#5', 'd': 'D5',
+        'D': 'D#5', 'f': 'E5', 'g': 'F5', 'G': 'F#5', 'h': 'G5',
+        'H': 'G#5', 'j': 'A5', 'J': 'A#5', 'k': 'B5', 'l': 'C6',
+        'L': 'C#6', 'z': 'D6', 'Z': 'D#6', 'x': 'E6', 'c': 'F6',
+        'C': 'F#6', 'v': 'G6', 'V': 'G#6', 'b': 'A6', 'B': 'A#6',
+        'n': 'B6', 'm': 'C7'
+    };
+
+    if ((typeof key === 'string' || typeof key === 'number')) {
+        return key in midi ? midi[key] : null;
+    } else {
+        throw new Error('You must enter a string or a number!');
+    }
+};
+
+const sanitiseBeat = (oldBeat, newBeat) => {
+
+    let clean = newBeat.replace(/\D/g, '');
+
+    if (typeof oldBeat === 'string' && typeof clean === 'string'
+        && !isNaN(clean) && !isNaN(oldBeat)) {
+        const intValue = parseInt(clean);
+
+        if (clean === '') {
+            return ''
+        } else {
+            return intValue > 0 && intValue <= 1000 ? clean : oldBeat;
+        }
+
+    } else {
+        throw new Error('You must enter an integer as a string!');
+    }
+};
+
+const createSprite = (values, volume) => {
+    const map = { sprite: {}, volume: volume / 100 };
+
+    values.forEach((item, index) => {
+        map.sprite[item] = [(index * 7652), 7648];
+    });
+
+    return map;
+};
+
+const isKeyBlack = (keyboard, current) => {
+    let item = keyboard[current];
+
+    if (Array.isArray(keyboard) && typeof (current) === 'number') {
+        return (current + 1 < keyboard.length
+            && isNaN(item) && item === item.toUpperCase());
+    } else {
+        throw new Error('You must enter a list and a number!');
+    };
+}
+
+export {
+    convertToNote,
+    sanitiseBeat,
+    createSprite,
+    isKeyBlack
+};

--- a/src/helpers.test.js
+++ b/src/helpers.test.js
@@ -1,0 +1,23 @@
+import { convertToNote } from './helpers';
+
+describe('Testing the convertToNote function', () => {
+
+    it('should return a string', () => {
+        expect(typeof convertToNote('t')).toBe('string');
+        expect(typeof convertToNote('u')).not.toBe('number');
+        expect(typeof convertToNote('y')).not.toBe('boolean');
+        expect(typeof convertToNote('o')).not.toBe('undefined');
+    });
+
+    it('should convert a valid keyboard key given as a string to a note', () => {
+        expect(convertToNote('q')).toBe('F3');
+    });
+
+    it('should throw an error if a string or a number is not given as an argument', () => {
+        expect(() => convertToNote(null)).toThrowError('You must enter a string or a number!');
+        expect(() => convertToNote([])).toThrowError('You must enter a string or a number!');
+        expect(() => convertToNote({})).toThrowError('You must enter a string or a number!');
+        expect(() => convertToNote()).toThrowError('You must enter a string or a number!');
+        expect(() => convertToNote(() => {})).toThrowError('You must enter a string or a number!');
+    });
+});


### PR DESCRIPTION
This is available at src/helpers.js:

![image](https://user-images.githubusercontent.com/90607671/150010122-d2ba43ae-5376-43d8-b9ba-4a82b005578f.png)

To help with testing logic, code was refactored into functions with specific functionality. The example above allows a regular keyboard key such as 'q' to be converted to its respective key ('F3'). This will be displayed in the bubble underneath the keyboard. A few initial tests for the convertToNote () function were also added.

This pull request also fixes an issue targeting the metronome, where using 0 as an input value would cause the metronome to play beats at an insanely high speed. The new helper function sanitiseBeat() helps ensure that the correct values are used for the metronome. 